### PR TITLE
Remove location from Add-PSCUCMPhone Parameters

### DIFF
--- a/PSCUCM/PSCUCM.psd1
+++ b/PSCUCM/PSCUCM.psd1
@@ -3,7 +3,7 @@
     RootModule        = 'PSCUCM.psm1'
 	
     # Version number of this module.
-    ModuleVersion     = '0.2.7'
+    ModuleVersion     = '0.2.8'
 	
     # ID used to uniquely identify this module
     GUID              = '6dce3384-d179-4bcd-92c0-445b281e4510'

--- a/PSCUCM/functions/device/Add-PSCUCMPhone.ps1
+++ b/PSCUCM/functions/device/Add-PSCUCMPhone.ps1
@@ -86,7 +86,6 @@
                 protocolSide          = $protocolSide
                 devicePoolName        = $devicePoolName
                 commonPhoneConfigName = $commonPhoneConfigName
-                locationName          = $locationName
                 useTrustedRelayPoint  = $useTrustedRelayPoint
                 phoneTemplateName     = $Template
                 primaryPhoneName      = $primaryPhoneName

--- a/README.md
+++ b/README.md
@@ -1,33 +1,5 @@
-# Description
+# Helpful information
 
-Insert a useful description for the PSCUCM project here.
+PSCUCM Uses AXL. Cisco maintains AXL information here: https://developer.cisco.com/site/axl/
 
-Remember, it's the first thing a visitor will see.
-
-# Project Setup Instructions
-## Working with the layout
-
- - Don't touch the psm1 file
- - Place functions you export in `functions/` (can have subfolders)
- - Place private/internal functions invisible to the user in `internal/functions` (can have subfolders)
- - Don't add code directly to the `postimport.ps1` or `preimport.ps1`.
-   Those files are designed to import other files only.
- - When adding files you load during `preimport.ps1`, be sure to add corresponding entries to `filesBefore.txt`.
-   The text files are used as reference when compiling the module during the build script.
- - When adding files you load during `postimport.ps1`, be sure to add corresponding entries to `filesAfter.txt`.
-   The text files are used as reference when compiling the module during the build script.
-
-## Setting up CI/CD
-
-> To create a PR validation pipeline, set up tasks like this:
-
- - Install Prerequisites (PowerShell Task; VSTS-Prerequisites.ps1)
- - Validate (PowerShell Task; VSTS-Validate.ps1)
- - Publish Test Results (Publish Test Results; NUnit format; Run no matter what)
-
-> To create a build/publish pipeline, set up tasks like this:
-
- - Install Prerequisites (PowerShell Task; VSTS-Prerequisites.ps1)
- - Validate (PowerShell Task; VSTS-Validate.ps1)
- - Build (PowerShell Task; VSTS-Build.ps1)
- - Publish Test Results (Publish Test Results; NUnit format; Run no matter what)
+Cisco has DevNet that allows you to spin up a test environment. It can be found here: https://devnetsandbox.cisco.com/RM/Topology


### PR DESCRIPTION
It seems that CUCM 11.5 was ok with this being null, but 12.5 is not. I've taken it out which should solve the issue for CUCM 12.5.

I'd like to flesh this out further to include most options as parameters, but don't have the cycles at the moment.

Fixes #47 